### PR TITLE
Add emojis to skipped reason errors and make it shorter by reducing details on skipped tests

### DIFF
--- a/src/Xchain/TestChainException.cs
+++ b/src/Xchain/TestChainException.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xchain;
 
 internal class TestChainException(Exception ex, TestChainErrors errors, string callerName, string callerFilePath, int callerLineNumber) 
-    : Exception($"{callerName} {(errors.Count > 0 ? "skipped" : "failed")} in {Path.GetFileName(callerFilePath)} line {callerLineNumber}.\n{ex.Message}{(ex.InnerException != null ? $"\n{ex.InnerException.Message}" : "")}", ex)
+    : Exception($"{(errors.Count > 0 ? "⚠️" : "❌")} {callerName} {(errors.Count > 0 ? "skipped" : "failed")} in {Path.GetFileName(callerFilePath)} line {callerLineNumber}.\n{ex.Message}{(ex.InnerException != null ? $"\n{ex.InnerException.Message}" : "")}", ex)
 {
 }

--- a/src/Xchain/TestChainException.cs
+++ b/src/Xchain/TestChainException.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xchain;
 
 internal class TestChainException(Exception ex, TestChainErrors errors, string callerName, string callerFilePath, int callerLineNumber) 
-    : Exception($"{(errors.Count > 0 ? "⚠️" : "❌")} {callerName} {(errors.Count > 0 ? "skipped" : "failed")} in {Path.GetFileName(callerFilePath)} line {callerLineNumber}.\n{ex.Message}{(ex.InnerException != null ? $"\n{ex.InnerException.Message}" : "")}", ex)
+    : Exception($"{(errors.Count > 0 ? "⚠️" : "❌")} {callerName} {(errors.Count > 0 ? "skipped" : "failed")}{(errors.Count > 0 ? "." : " in " + Path.GetFileName(callerFilePath) + " line " + callerLineNumber) + "\n" + ex.Message + (ex.InnerException != null ? $"\n{ex.InnerException.Message}" : "") }", ex)
 {
 }


### PR DESCRIPTION
- [x] Make the skipped reason shorter. Do not include details about class and line of code for skipped tests.
- [x] Add failed and warning emojis to the test chain exception and prerelease a new nugget
