### PR TITLE
Add async dispose support for DI fixtures and per-link scopes

### DIFF
--- a/src/Xchain.DependencyInjection/ServiceProviderFixture.cs
+++ b/src/Xchain.DependencyInjection/ServiceProviderFixture.cs
@@ -1,14 +1,18 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xchain.DependencyInjection.Logging;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Xchain.DependencyInjection;
 
-public sealed class ServiceProviderFixture(IMessageSink messageSink) : IServiceProviderFixture, IAsyncDisposable, IDisposable
+public sealed class ServiceProviderFixture(IMessageSink messageSink) : IServiceProviderFixture, IAsyncLifetime, IAsyncDisposable
 {
     private ServiceProvider? _provider;
     private readonly object _lock = new();
+
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    Task IAsyncLifetime.DisposeAsync() => DisposeAsync().AsTask();
 
     public IServiceProvider Services => _provider
         ?? throw new InvalidOperationException("Call Build() before accessing Services.");
@@ -39,13 +43,7 @@ public sealed class ServiceProviderFixture(IMessageSink messageSink) : IServiceP
         if (_provider is null) return;
         await _provider.StopHostedServicesAsync(messageSink);
         await _provider.DisposeAsync();
-    }
-
-    public void Dispose()
-    {
-        if (_provider is null) return;
-        _provider.StopHostedServices(messageSink);
-        _provider.Dispose();
+        _provider = null;
     }
 
     internal static IConfiguration BuildConfiguration()

--- a/src/Xchain.DependencyInjection/ServiceProviderFixtureExtensions.cs
+++ b/src/Xchain.DependencyInjection/ServiceProviderFixtureExtensions.cs
@@ -57,7 +57,7 @@ public static class ServiceProviderFixtureExtensions
     {
         try
         {
-            using var scope = fixture.Services.CreateScope();
+            await using var scope = fixture.Services.CreateAsyncScope();
             using var cts = timeOut != default
                 ? new CancellationTokenSource(timeOut)
                 : new CancellationTokenSource();
@@ -87,7 +87,7 @@ public static class ServiceProviderFixtureExtensions
     {
         try
         {
-            using var scope = fixture.Services.CreateScope();
+            await using var scope = fixture.Services.CreateAsyncScope();
             using var cts = timeOut != default
                 ? new CancellationTokenSource(timeOut)
                 : new CancellationTokenSource();
@@ -163,7 +163,7 @@ public static class ServiceProviderFixtureExtensions
         {
             var existing = chain.Errors.FirstOrDefault(ex => ex.InnerException is TException);
             Skip.If(existing is not null, existing?.Message);
-            using var scope = fixture.Services.CreateScope();
+            await using var scope = fixture.Services.CreateAsyncScope();
             using var cts = timeOut != default
                 ? new CancellationTokenSource(timeOut)
                 : new CancellationTokenSource();
@@ -195,7 +195,7 @@ public static class ServiceProviderFixtureExtensions
         {
             var existing = chain.Errors.FirstOrDefault(ex => ex.InnerException is TException);
             Skip.If(existing is not null, existing?.Message);
-            using var scope = fixture.Services.CreateScope();
+            await using var scope = fixture.Services.CreateAsyncScope();
             using var cts = timeOut != default
                 ? new CancellationTokenSource(timeOut)
                 : new CancellationTokenSource();

--- a/src/Xchain.DependencyInjection/WorkflowServiceProviderFixture.cs
+++ b/src/Xchain.DependencyInjection/WorkflowServiceProviderFixture.cs
@@ -55,15 +55,17 @@ public abstract class WorkflowServiceProviderFixture<TSelf>(IMessageSink message
     /// Stops hosted services and disposes the static provider.
     /// Call from the last collection in the workflow chain for graceful shutdown.
     /// </summary>
-    public static void Teardown(IMessageSink? sink = null)
+    public static async Task TeardownAsync(IMessageSink? sink = null)
     {
+        ServiceProvider? toDispose;
         lock (_lock)
         {
             if (_provider is null) return;
-            if (sink is not null)
-                _provider.StopHostedServices(sink);
-            _provider.Dispose();
+            toDispose = _provider;
             _provider = null;
         }
+        if (sink is not null)
+            await toDispose.StopHostedServicesAsync(sink);
+        await toDispose.DisposeAsync();
     }
 }

--- a/src/Xchain.DependencyInjection/WorkflowTeardownFixture.cs
+++ b/src/Xchain.DependencyInjection/WorkflowTeardownFixture.cs
@@ -1,9 +1,11 @@
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Xchain.DependencyInjection;
 
-public sealed class WorkflowTeardownFixture<TWorkflow>(IMessageSink sink) : IDisposable
+public sealed class WorkflowTeardownFixture<TWorkflow>(IMessageSink sink) : IAsyncLifetime
     where TWorkflow : WorkflowServiceProviderFixture<TWorkflow>
 {
-    public void Dispose() => WorkflowServiceProviderFixture<TWorkflow>.Teardown(sink);
+    Task IAsyncLifetime.InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => WorkflowServiceProviderFixture<TWorkflow>.TeardownAsync(sink);
 }

--- a/src/Xchain.Tests/DependencyInjection/Helpers/PublicAsyncOnlyDisposable.cs
+++ b/src/Xchain.Tests/DependencyInjection/Helpers/PublicAsyncOnlyDisposable.cs
@@ -1,0 +1,12 @@
+namespace Xchain.Tests.DependencyInjection.Helpers;
+
+public sealed class PublicAsyncOnlyDisposable : IAsyncDisposable
+{
+    public bool Disposed { get; private set; }
+
+    public ValueTask DisposeAsync()
+    {
+        Disposed = true;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Xchain.Tests/DependencyInjection/IntegrationTest.cs
+++ b/src/Xchain.Tests/DependencyInjection/IntegrationTest.cs
@@ -85,9 +85,10 @@ public sealed class IntegrationTest(
 /// simulating the across-collection-boundary property (collection A's fixture disposed, collection B's
 /// fixture created — both resolve to the same static provider built exactly once).
 /// </summary>
-public sealed class WorkflowScopeAcrossBoundaryTest : IDisposable
+public sealed class WorkflowScopeAcrossBoundaryTest : IAsyncLifetime
 {
-    public void Dispose() => BoundaryWorkflow.Teardown();
+    public Task InitializeAsync() => Task.CompletedTask;
+    public Task DisposeAsync() => BoundaryWorkflow.TeardownAsync();
 
     [Fact]
     public void StaticProvider_SurvivesFixtureDisposal_SameInstance()

--- a/src/Xchain.Tests/DependencyInjection/LoggingBridgeTest.cs
+++ b/src/Xchain.Tests/DependencyInjection/LoggingBridgeTest.cs
@@ -9,10 +9,10 @@ namespace Xchain.Tests.DependencyInjection;
 public sealed class LoggingBridgeTest
 {
     [Fact]
-    public void ILogger_RoutesToMessageSink()
+    public async Task ILogger_RoutesToMessageSink()
     {
         var sink = new SpyMessageSink();
-        using var fixture = new ServiceProviderFixture(sink);
+        await using var fixture = new ServiceProviderFixture(sink);
         fixture.Build();
 
         var logger = fixture.Services.GetRequiredService<ILogger<LoggingBridgeTest>>();

--- a/src/Xchain.Tests/DependencyInjection/PerLinkScopeTest.cs
+++ b/src/Xchain.Tests/DependencyInjection/PerLinkScopeTest.cs
@@ -7,10 +7,10 @@ namespace Xchain.Tests.DependencyInjection;
 public sealed class PerLinkScopeTest
 {
     [Fact]
-    public void Link_ScopedService_NewInstancePerCall()
+    public async Task Link_ScopedService_NewInstancePerCall()
     {
         var sink = new SpyMessageSink();
-        using var fixture = new ServiceProviderFixture(sink);
+        await using var fixture = new ServiceProviderFixture(sink);
         fixture.Build(configure: (services, _) => services.AddScoped<Counter>());
 
         var chain = new TestChainContextFixture();
@@ -27,10 +27,10 @@ public sealed class PerLinkScopeTest
     }
 
     [Fact]
-    public void Link_SingletonService_SameInstanceAcrossCalls()
+    public async Task Link_SingletonService_SameInstanceAcrossCalls()
     {
         var sink = new SpyMessageSink();
-        using var fixture = new ServiceProviderFixture(sink);
+        await using var fixture = new ServiceProviderFixture(sink);
         fixture.Build(configure: (services, _) => services.AddSingleton<Counter>());
 
         var chain = new TestChainContextFixture();
@@ -45,10 +45,10 @@ public sealed class PerLinkScopeTest
     }
 
     [Fact]
-    public void Link_Exception_PushedToChainErrors()
+    public async Task Link_Exception_PushedToChainErrors()
     {
         var sink = new SpyMessageSink();
-        using var fixture = new ServiceProviderFixture(sink);
+        await using var fixture = new ServiceProviderFixture(sink);
         fixture.Build();
 
         var chain = new TestChainContextFixture();
@@ -66,7 +66,7 @@ public sealed class PerLinkScopeTest
     public async Task LinkAsync_ScopedService_NewInstancePerCall()
     {
         var sink = new SpyMessageSink();
-        using var fixture = new ServiceProviderFixture(sink);
+        await using var fixture = new ServiceProviderFixture(sink);
         fixture.Build(configure: (services, _) => services.AddScoped<Counter>());
 
         var chain = new TestChainContextFixture();
@@ -94,7 +94,7 @@ public sealed class PerLinkScopeTest
     public async Task LinkAsync_Timeout_ThrowsTimeoutException()
     {
         var sink = new SpyMessageSink();
-        using var fixture = new ServiceProviderFixture(sink);
+        await using var fixture = new ServiceProviderFixture(sink);
         fixture.Build();
 
         var chain = new TestChainContextFixture();
@@ -107,10 +107,10 @@ public sealed class PerLinkScopeTest
     }
 
     [Fact]
-    public void LinkUnless_SkipsWhenErrorPresent()
+    public async Task LinkUnless_SkipsWhenErrorPresent()
     {
         var sink = new SpyMessageSink();
-        using var fixture = new ServiceProviderFixture(sink);
+        await using var fixture = new ServiceProviderFixture(sink);
         fixture.Build();
 
         var chain = new TestChainContextFixture();
@@ -127,10 +127,10 @@ public sealed class PerLinkScopeTest
     }
 
     [Fact]
-    public void Link_Output_SharedViaChain()
+    public async Task Link_Output_SharedViaChain()
     {
         var sink = new SpyMessageSink();
-        using var fixture = new ServiceProviderFixture(sink);
+        await using var fixture = new ServiceProviderFixture(sink);
         fixture.Build();
 
         var chain = new TestChainContextFixture();

--- a/src/Xchain.Tests/DependencyInjection/ServiceProviderFixtureTest.cs
+++ b/src/Xchain.Tests/DependencyInjection/ServiceProviderFixtureTest.cs
@@ -8,10 +8,10 @@ namespace Xchain.Tests.DependencyInjection;
 public sealed class ServiceProviderFixtureTest
 {
     [Fact]
-    public void Build_IsIdempotent_ReturnsSameProvider()
+    public async Task Build_IsIdempotent_ReturnsSameProvider()
     {
         var sink = new SpyMessageSink();
-        using var fixture = new ServiceProviderFixture(sink);
+        await using var fixture = new ServiceProviderFixture(sink);
 
         var first = fixture.Build();
         var second = fixture.Build();
@@ -20,19 +20,19 @@ public sealed class ServiceProviderFixtureTest
     }
 
     [Fact]
-    public void Services_BeforeBuild_Throws()
+    public async Task Services_BeforeBuild_Throws()
     {
         var sink = new SpyMessageSink();
-        using var fixture = new ServiceProviderFixture(sink);
+        await using var fixture = new ServiceProviderFixture(sink);
 
         Assert.Throws<InvalidOperationException>(() => fixture.Services);
     }
 
     [Fact]
-    public void Services_AfterBuild_ReturnsSameProvider()
+    public async Task Services_AfterBuild_ReturnsSameProvider()
     {
         var sink = new SpyMessageSink();
-        using var fixture = new ServiceProviderFixture(sink);
+        await using var fixture = new ServiceProviderFixture(sink);
 
         var built = fixture.Build();
 
@@ -40,10 +40,10 @@ public sealed class ServiceProviderFixtureTest
     }
 
     [Fact]
-    public void Build_Configure_RegistersServices()
+    public async Task Build_Configure_RegistersServices()
     {
         var sink = new SpyMessageSink();
-        using var fixture = new ServiceProviderFixture(sink);
+        await using var fixture = new ServiceProviderFixture(sink);
 
         fixture.Build(configure: (services, _) => services.AddSingleton<string>("hello"));
 
@@ -52,10 +52,10 @@ public sealed class ServiceProviderFixtureTest
     }
 
     [Fact]
-    public void Build_RegistersConfiguration_AsService()
+    public async Task Build_RegistersConfiguration_AsService()
     {
         var sink = new SpyMessageSink();
-        using var fixture = new ServiceProviderFixture(sink);
+        await using var fixture = new ServiceProviderFixture(sink);
         fixture.Build();
 
         var config = fixture.Services.GetService<Microsoft.Extensions.Configuration.IConfiguration>();
@@ -63,7 +63,7 @@ public sealed class ServiceProviderFixtureTest
     }
 
     [Fact]
-    public void Dispose_StopsHostedService()
+    public async Task DisposeAsync_StopsHostedService()
     {
         var sink = new SpyMessageSink();
         var spy = new FakeHostedService();
@@ -72,23 +72,64 @@ public sealed class ServiceProviderFixtureTest
         fixture.Build(configure: (services, _) => services.AddSingleton<IHostedService>(spy));
 
         Assert.True(spy.Started);
-        fixture.Dispose();
+        await fixture.DisposeAsync();
 
         Assert.True(spy.Stopped);
         Assert.Contains(sink.Messages, m => m.Contains("stopped FakeHostedService"));
     }
 
     [Fact]
-    public void Build_StartsHostedService()
+    public async Task Build_StartsHostedService()
     {
         var sink = new SpyMessageSink();
         var spy = new FakeHostedService();
 
-        using var fixture = new ServiceProviderFixture(sink);
+        await using var fixture = new ServiceProviderFixture(sink);
         fixture.Build(configure: (services, _) => services.AddSingleton<IHostedService>(spy));
 
         Assert.True(spy.Started);
         Assert.Contains(sink.Messages, m => m.Contains("started FakeHostedService"));
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WithAsyncOnlyDisposableService_DisposesService()
+    {
+        // The container must call DisposeAsync() on IAsyncDisposable-only singleton services.
+        // Use a public top-level service type so the DI engine can construct it via reflection.
+        var sink = new SpyMessageSink();
+        var fixture = new ServiceProviderFixture(sink);
+        fixture.Build(configure: (services, _) => services.AddSingleton<PublicAsyncOnlyDisposable>());
+        var asyncDisposable = fixture.Services.GetRequiredService<PublicAsyncOnlyDisposable>();
+
+        await fixture.DisposeAsync();
+
+        Assert.True(asyncDisposable.Disposed);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WithAsyncOnlyDisposableService_DoesNotThrow()
+    {
+        var sink = new SpyMessageSink();
+        var fixture = new ServiceProviderFixture(sink);
+        fixture.Build(configure: (services, _) => services.AddSingleton<PublicAsyncOnlyDisposable>());
+        _ = fixture.Services.GetRequiredService<PublicAsyncOnlyDisposable>();
+
+        var ex = await Record.ExceptionAsync(() => fixture.DisposeAsync().AsTask());
+
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_IsIdempotent()
+    {
+        var sink = new SpyMessageSink();
+        var fixture = new ServiceProviderFixture(sink);
+        fixture.Build();
+
+        await fixture.DisposeAsync();
+        var ex = await Record.ExceptionAsync(() => fixture.DisposeAsync().AsTask());
+
+        Assert.Null(ex);
     }
 
     private sealed class FakeHostedService : IHostedService
@@ -108,4 +149,5 @@ public sealed class ServiceProviderFixtureTest
             return Task.CompletedTask;
         }
     }
+
 }

--- a/src/Xchain.Tests/DependencyInjection/WorkflowServiceProviderFixtureTest.cs
+++ b/src/Xchain.Tests/DependencyInjection/WorkflowServiceProviderFixtureTest.cs
@@ -7,16 +7,19 @@ using Xunit.Abstractions;
 
 namespace Xchain.Tests.DependencyInjection;
 
-public sealed class WorkflowServiceProviderFixtureTest : IDisposable
+public sealed class WorkflowServiceProviderFixtureTest : IAsyncLifetime
 {
-    public void Dispose()
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
     {
         // Reset static slots after each test to prevent cross-test contamination.
-        WorkflowA.Teardown();
-        WorkflowB.Teardown();
-        WorkflowC.Teardown();
-        WorkflowD.Teardown();
-        UninitializedWorkflow.Teardown();
+        await WorkflowA.TeardownAsync();
+        await WorkflowB.TeardownAsync();
+        await WorkflowC.TeardownAsync();
+        await WorkflowD.TeardownAsync();
+        await WorkflowE.TeardownAsync();
+        await UninitializedWorkflow.TeardownAsync();
     }
 
     [Fact]
@@ -41,41 +44,41 @@ public sealed class WorkflowServiceProviderFixtureTest : IDisposable
     }
 
     [Fact]
-    public void Teardown_DisposesProvider_AllowsRebuild()
+    public async Task TeardownAsync_DisposesProvider_AllowsRebuild()
     {
         var sink = new SpyMessageSink();
         var first = new WorkflowA(sink);
         var providerBefore = first.Services;
 
-        WorkflowA.Teardown(sink);
+        await WorkflowA.TeardownAsync(sink);
 
         var second = new WorkflowA(sink);
         Assert.NotSame(providerBefore, second.Services);
     }
 
     [Fact]
-    public void Teardown_StopsHostedService()
+    public async Task TeardownAsync_StopsHostedService()
     {
         var sink = new SpyMessageSink();
         var spy = new FakeHostedService();
-        var fixture = new WorkflowC(sink, spy);
+        _ = new WorkflowC(sink, spy);
 
         Assert.True(spy.Started);
-        WorkflowC.Teardown(sink);
+        await WorkflowC.TeardownAsync(sink);
 
         Assert.True(spy.Stopped);
         Assert.Contains(sink.Messages, m => m.Contains("stopped FakeHostedService"));
     }
 
     [Fact]
-    public void WorkflowTeardownFixture_Dispose_StopsHostedServiceAndDisposesProvider()
+    public async Task WorkflowTeardownFixture_DisposeAsync_StopsHostedServiceAndDisposesProvider()
     {
         var sink = new SpyMessageSink();
         var spy = new FakeHostedService();
         _ = new WorkflowD(sink, spy);
 
         var teardown = new WorkflowTeardownFixture<WorkflowD>(sink);
-        teardown.Dispose();
+        await teardown.DisposeAsync();
 
         Assert.True(spy.Stopped);
         Assert.Contains(sink.Messages, m => m.Contains("stopped FakeHostedService"));
@@ -87,6 +90,32 @@ public sealed class WorkflowServiceProviderFixtureTest : IDisposable
         var fixture = new UninitializedWorkflow(new SpyMessageSink());
         var ex = Assert.Throws<InvalidOperationException>(() => { _ = fixture.Services; });
         Assert.Contains("Initialize()", ex.Message);
+    }
+
+    [Fact]
+    public async Task TeardownAsync_WithAsyncOnlyDisposableService_DisposesService()
+    {
+        var sink = new SpyMessageSink();
+        var workflow = new WorkflowE(sink);
+
+        // Resolve so the container creates and tracks the instance for disposal.
+        var asyncDisposable = workflow.Services.GetRequiredService<PublicAsyncOnlyDisposable>();
+
+        await WorkflowE.TeardownAsync(sink);
+
+        Assert.True(asyncDisposable.Disposed);
+    }
+
+    [Fact]
+    public async Task TeardownAsync_IsIdempotent()
+    {
+        var sink = new SpyMessageSink();
+        _ = new WorkflowA(sink);
+
+        await WorkflowA.TeardownAsync(sink);
+        var ex = await Record.ExceptionAsync(() => WorkflowA.TeardownAsync(sink));
+
+        Assert.Null(ex);
     }
 
     // ---- Inner fixture types — each uses a unique type param to isolate static slots ----
@@ -141,6 +170,14 @@ public sealed class WorkflowServiceProviderFixtureTest : IDisposable
         }
     }
 
+    private sealed class WorkflowE : WorkflowServiceProviderFixture<WorkflowE>
+    {
+        public WorkflowE(IMessageSink sink) : base(sink) => Initialize();
+
+        protected override void ConfigureServices(IServiceCollection services, IConfiguration config)
+            => services.AddSingleton<PublicAsyncOnlyDisposable>();
+    }
+
     private sealed class UninitializedWorkflow : WorkflowServiceProviderFixture<UninitializedWorkflow>
     {
         public UninitializedWorkflow(IMessageSink sink) : base(sink) { }
@@ -154,4 +191,5 @@ public sealed class WorkflowServiceProviderFixtureTest : IDisposable
         public Task StartAsync(CancellationToken ct) { Started = true; return Task.CompletedTask; }
         public Task StopAsync(CancellationToken ct) { Stopped = true; return Task.CompletedTask; }
     }
+
 }


### PR DESCRIPTION
## Summary

- Switch `ServiceProviderFixture` and `WorkflowTeardownFixture` to `IAsyncLifetime`/`IAsyncDisposable`, removing synchronous `Dispose` so hosted services and `IAsyncDisposable` registrations tear down correctly
- Use `CreateAsyncScope()` with `await using` in per-link `Link*` extensions so scoped services dispose asynchronously
- Replace `WorkflowServiceProviderFixture.Teardown` with `TeardownAsync`, stopping hosted services and disposing the provider via async APIs
- Add tests covering `IAsyncDisposable`-only services, idempotent teardown, and updated integration/workflow fixture cleanup

## Test plan

- [ ] Run `dotnet test Xchain.slnx --filter "FullyQualifiedName~DependencyInjection"` and confirm all tests pass
- [ ] Verify `ServiceProviderFixture.DisposeAsync` stops hosted services and disposes `IAsyncDisposable`-only singletons without throwing
- [ ] Exercise a multi-collection workflow with `WorkflowTeardownFixture` and confirm `TeardownAsync` runs cleanly at the end of the chain
- [ ] Confirm per-link `LinkAsync` scopes dispose async-only scoped services when the link completes